### PR TITLE
build: set the version prefix to only contain the last git tag

### DIFF
--- a/make/main.go
+++ b/make/main.go
@@ -156,7 +156,7 @@ func main() {
 }
 
 func getGitTag() string {
-	if des, err := getCommandOutput("git", "describe", "--tags"); err == nil {
+	if des, err := getCommandOutput("git", "describe", "--tag", "--abbrev=0"); err == nil {
 		return des
 	}
 


### PR DESCRIPTION
Fixes #103 

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
