### PR TITLE
feat(pkg/validation): make the npm package name lax by default

### DIFF
--- a/pkg/validate/npm_package_name.go
+++ b/pkg/validate/npm_package_name.go
@@ -25,11 +25,23 @@ import (
 
 func isNpmPackageName(fl validator.FieldLevel) bool {
 	field := fl.Field()
+	// Do you want strict validation or not?
+	strict := false
+	switch fl.Param() {
+	case "strict":
+		strict = true
+	}
 
 	if field.Kind() == reflect.String {
 		valid, warnings, err := npmpackagename.Validate([]byte(field.String()))
-		if err == nil && len(warnings) == 0 {
-			return valid
+		if strict {
+			if err == nil && len(warnings) == 0 {
+				return valid
+			}
+		} else {
+			if err == nil {
+				return valid
+			}
 		}
 
 		return false


### PR DESCRIPTION
This way we do not block our users from asking verdicts about previously valid npm package names (eg., `events` or other builtins).

Try it out with:

```bash
./lstn --endpoint=https://npm-staging.listen.dev to events
```

Fixes #121 

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
