### PR TITLE
feat: scan the package.json dependencies

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/listendev/lstn/cmd/in"
+	"github.com/listendev/lstn/cmd/scan"
 	"github.com/listendev/lstn/cmd/to"
 	"github.com/listendev/lstn/cmd/version"
 	"github.com/listendev/lstn/internal/project"
@@ -213,6 +214,13 @@ func New(ctx context.Context) (*Command, error) {
 		return nil, err
 	}
 	rootCmd.AddCommand(toCmd)
+
+	// Setup the `scan` subcommand
+	scanCmd, err := scan.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(scanCmd)
 
 	// Setup the `version` subcommand
 	versionCmd, err := version.New(ctx)

--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2023 The listen.dev team <engineering@garnet.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package scan
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/XANi/goneric"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/listendev/lstn/internal/project"
+	"github.com/listendev/lstn/pkg/cmd/arguments"
+	"github.com/listendev/lstn/pkg/cmd/groups"
+	"github.com/listendev/lstn/pkg/cmd/options"
+	pkgcontext "github.com/listendev/lstn/pkg/context"
+	"github.com/listendev/lstn/pkg/listen"
+	"github.com/listendev/lstn/pkg/npm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	_, filename, _, _ = runtime.Caller(0)
+)
+
+func New(ctx context.Context) (*cobra.Command, error) {
+	var scanCmd = &cobra.Command{
+		Use:                   "scan <path>",
+		GroupID:               groups.Core.ID,
+		DisableFlagsInUseLine: true,
+		Short:                 "Inspect the verdicts for your direct dependencies",
+		Long: `Query listen.dev for the verdicts of the dependencies in your project.
+
+Using this command, you can audit the first-level dependencies configured for a project and obtain their verdicts.
+This requires a package.json file to fetch the package name and version of the project dependencies.
+
+The verdicts it returns are listed by the name of each package and its specified version.`,
+		Example: `  lstn scan
+  lstn scan .
+  lstn scan /we/snitch
+  lstn scan sub/dir`,
+		Args:              arguments.SingleDirectory, // Executes before RunE
+		ValidArgsFunction: arguments.SingleDirectoryActiveHelp,
+		Annotations: map[string]string{
+			"source": project.GetSourceURL(filename),
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx = c.Context()
+
+			// Obtain the local options from the context
+			opts, err := options.GetFromContext(ctx, pkgcontext.ScanKey)
+			if err != nil {
+				return err
+			}
+			scanOpts, ok := opts.(*options.Scan)
+			if !ok {
+				return fmt.Errorf("couldn't obtain options for the current child command")
+			}
+
+			// Obtain the target directory that we want to listen in
+			targetDir, err := arguments.GetDirectory(args)
+			if err != nil {
+				return fmt.Errorf("couldn't get to know which directory you want me to scan")
+			}
+
+			packageJSON, err := npm.GetPackageJSONFromDir(targetDir)
+			if err != nil {
+				return err
+			}
+
+			dependenciesTypes := []npm.DependencyType{
+				npm.Dependencies,
+				npm.DevDependencies,
+				npm.PeerDependencies,
+				npm.OptionalDependencies,
+			}
+
+			deps := packageJSON.Deps(ctx, npm.DefaultVersionResolutionStrategy, dependenciesTypes...)
+
+			for _, deps := range deps {
+				names := goneric.MapSliceKey(deps)
+				versions := goneric.MapSliceValue(deps)
+				// Create list of verdicts requests
+				reqs, err := listen.NewBulkVerdictsRequests(names, versions)
+				if err != nil {
+					return err
+				}
+
+				// Query for verdicts about specific package versions...
+				res, resJSON, resErr := listen.BulkPackages(reqs, listen.WithContext(ctx), listen.WithJSONOptions(scanOpts.JSONFlags))
+
+				if resErr != nil {
+					return err
+				}
+
+				if resJSON != nil {
+					fmt.Fprintf(os.Stdout, "%s", resJSON)
+				}
+
+				if res != nil {
+					spew.Dump(res)
+					// TODO > create visualization of the results
+				}
+			}
+
+			return nil
+		},
+	}
+
+	// Obtain the local options
+	scanOpts, err := options.NewScan()
+	if err != nil {
+		return nil, err
+	}
+
+	// Persistent flags here will work for this command and all subcommands
+	// scanCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Local flags will only run when this command is called directly
+	scanOpts.Attach(scanCmd)
+
+	// Pass the options through the context
+	ctx = context.WithValue(ctx, pkgcontext.ScanKey, scanOpts)
+	scanCmd.SetContext(ctx)
+
+	return scanCmd, nil
+}

--- a/cmd/to/to.go
+++ b/cmd/to/to.go
@@ -56,8 +56,11 @@ It lists out the verdicts of all the versions of the input package name.`,
 
   # Get the verdicts for all the existing chalk versions
   lstn to chalk "*"
-  lstn to nock "~13.2"
-  lstn to tap "^16.3.4"
+  # Get the verdicts for nock versions >= 13.2.0 and < 13.3.0
+  lstn to nock "~13.2.x"
+  # Get the verdicts for tap versions >= 16.3.0 and < 16.4.0
+  lstn to tap "^16.3.0"
+  # Get the verdicts for prettier versions >= 2.7.0 <= 3.0.0
   lstn to prettier ">=2.7.0 <=3.0.0"`,
 		Args:              arguments.PackageTriple, // Executes before RunE
 		ValidArgsFunction: arguments.PackageTripleActiveHelp,
@@ -83,15 +86,20 @@ It lists out the verdicts of all the versions of the input package name.`,
 
 			versions, multiple := ctx.Value(pkgcontext.VersionsCollection).(semver.Collection)
 			if multiple {
+				nv := len(versions)
+
+				names := make([]string, nv)
+				for i := 0; i < nv; i++ {
+					names[i] = args[0]
+				}
+
 				// Create list of verdicts requests
-				reqs, multipleErr := listen.NewVerdictsRequestsFromVersionCollection(args, versions)
+				reqs, multipleErr := listen.NewBulkVerdictsRequests(names, versions)
 				if multipleErr != nil {
 					return multipleErr
 				}
-				// spew.Dump(reqs)
 
 				// Query for verdicts about specific package versions...
-
 				res, resJSON, resErr = listen.BulkPackages(reqs, listen.WithContext(ctx), listen.WithJSONOptions(toOpts.JSONFlags))
 
 				goto EXIT

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -49,7 +49,7 @@ func New(ctx context.Context) (*cobra.Command, error) {
 			}
 			localOpts, ok := opts.(*options.Version)
 			if !ok {
-				return fmt.Errorf("couldn't obtain options for the current subcommand")
+				return fmt.Errorf("couldn't obtain options for the current child command")
 			}
 
 			// Obtain the version info from the context

--- a/pkg/cmd/arguments/dir.go
+++ b/pkg/cmd/arguments/dir.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2023 The listen.dev team <engineering@garnet.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package arguments
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/listendev/lstn/pkg/validate"
+	"github.com/spf13/cobra"
+)
+
+// SingleDirectory validates the input arguments is a single directory.
+//
+// It checks that there is maximum one argument.
+// It checks that the argument is an existing directory, too.
+func SingleDirectory(c *cobra.Command, args []string) error {
+	if err := cobra.MaximumNArgs(1)(c, args); err != nil {
+		return err
+	}
+	// No further validation left if there are no arguments at all
+	if len(args) == 0 {
+		return nil
+	}
+	if errs := validate.Singleton.Var(args[0], "dir"); errs != nil {
+		return fmt.Errorf("requires the argument to be an existing directory")
+	}
+	// Check that the target directory contains a package.json file
+	packageJSONErrors := validate.Singleton.Var(filepath.Join(args[0], "package.json"), "file")
+	// NOTE > In the future, we can try to detect other package managers here rather than erroring out
+	if packageJSONErrors != nil {
+		return fmt.Errorf("couldn't find a package.json in %s", args[0])
+	}
+
+	return nil
+}
+
+// GetDirectory computes the absolute path from the input arguments.
+//
+// When no argument has been specified, it return the current working directory.
+func GetDirectory(args []string) (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) > 0 {
+		dir = args[0]
+	}
+
+	return filepath.Abs(dir)
+}
+
+// SingleDirectoryActiveHelp generates the active help for a single directory.
+func SingleDirectoryActiveHelp(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// TODO:  Double-check it's working.
+	var comps []string
+	switch len(args) {
+	case 0:
+		comps = cobra.AppendActiveHelp(comps, "Executing against the current working directory")
+	case 1:
+		comps = cobra.AppendActiveHelp(comps, fmt.Sprintf("Executing against directory '%s'", args[0]))
+	default:
+		comps = cobra.AppendActiveHelp(comps, "This command does not take any more arguments")
+	}
+
+	return comps, cobra.ShellCompDirectiveFilterDirs
+}

--- a/pkg/cmd/options/scan.go
+++ b/pkg/cmd/options/scan.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2023 The listen.dev team <engineering@garnet.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package options
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/creasty/defaults"
+	"github.com/listendev/lstn/pkg/cmd/flags"
+	"github.com/listendev/lstn/pkg/cmd/flagusages"
+	"github.com/spf13/cobra"
+)
+
+type Scan struct {
+	flags.JSONFlags
+	flags.ConfigFlags `flagset:"Config"`
+}
+
+func NewScan() (*Scan, error) {
+	o := &Scan{}
+
+	if err := defaults.Set(o); err != nil {
+		return nil, fmt.Errorf("error setting configuration defaults")
+	}
+
+	return o, nil
+}
+
+func (o *Scan) Attach(c *cobra.Command) {
+	flags.Define(c, o, "")
+	flagusages.Set(c)
+}
+
+func (o *Scan) Validate() []error {
+	return flags.Validate(o)
+}
+
+func (o *Scan) Transform(ctx context.Context) error {
+	return flags.Transform(ctx, o)
+}

--- a/pkg/context/keys.go
+++ b/pkg/context/keys.go
@@ -32,6 +32,9 @@ var ToKey contextKey = "to"
 // VersionsCollection is the key indexing a versions collection.
 var VersionsCollection contextKey = "versionscollection"
 
+// ScanKey is the key indexing the options for the `scan` child command.
+var ScanKey contextKey = "scan"
+
 // VersionKey is the key indexing the options for the `version` child command.
 var VersionKey contextKey = "version"
 

--- a/pkg/listen/req.go
+++ b/pkg/listen/req.go
@@ -73,15 +73,16 @@ func NewVerdictsRequest(args []string) (*VerdictsRequest, error) {
 	return fillVerdictsRequest(ret, args)
 }
 
-func NewVerdictsRequestsFromVersionCollection(args []string, versions semver.Collection) ([]*VerdictsRequest, error) {
+func NewBulkVerdictsRequests(names []string, versions semver.Collection) ([]*VerdictsRequest, error) {
+	if len(names) != len(versions) {
+		return nil, fmt.Errorf("couldn't create a request set because of mismatching lenghts")
+	}
+
 	c := NewContext()
 
 	reqs := make([]*VerdictsRequest, len(versions))
 	for i, v := range versions {
-		inputs := []string{args[0], v.String()}
-		if len(args) > 2 {
-			inputs = append(inputs, args[2])
-		}
+		inputs := []string{names[i], v.String()}
 		var reqErr error
 		reqs[i], reqErr = NewVerdictsRequestWithContext(inputs, c)
 		if reqErr != nil {

--- a/pkg/npm/deps_test.go
+++ b/pkg/npm/deps_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2023 The listen.dev team <engineering@garnet.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package npm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDepsByType(t *testing.T) {
+	e1 := map[string]string{
+		"react": "18.0.0",
+	}
+
+	p1 := &packageJSON{
+		Dependencies: e1,
+	}
+
+	assert.Equal(t, e1, p1.getDepsByType(Dependencies))
+	assert.Equal(t, map[string]string{}, p1.getDepsByType(DevDependencies))
+
+	e2 := map[string]string{
+		"react":      "18.0.0",
+		"node-fetch": "2.6.9",
+	}
+
+	p2 := &packageJSON{
+		DevDependencies: e2,
+	}
+
+	assert.Equal(t, map[string]string{}, p2.getDepsByType(Dependencies))
+	assert.Equal(t, e2, p2.getDepsByType(DevDependencies))
+}

--- a/pkg/npm/package.go
+++ b/pkg/npm/package.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2023 The listen.dev team <engineering@garnet.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package npm
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+)
+
+func readPackageJSON(dir string) (io.Reader, error) {
+	f, err := activeFS.Open(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read the package.json file")
+	}
+
+	return f, nil
+}

--- a/pkg/npm/types.go
+++ b/pkg/npm/types.go
@@ -63,7 +63,7 @@ type packageJSON struct {
 }
 
 type PackageJSON interface {
-	Deps(context.Context, VersionResolutionStrategy, ...DependencyType) map[DependencyType]map[string]semver.Version
+	Deps(context.Context, VersionResolutionStrategy, ...DependencyType) map[DependencyType]map[string]*semver.Version
 }
 
 // The VersionResolutionStrategy is a function that, given a version constraints,

--- a/pkg/npm/version_strategy.go
+++ b/pkg/npm/version_strategy.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2023 The listen.dev team <engineering@garnet.ai>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package npm
+
+import (
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// DefaultVersionResolutionStrategy returns the highest semantic version in a collection of versions.
+func DefaultVersionResolutionStrategy(versions semver.Collection) *semver.Version {
+	sort.Sort(versions)
+
+	return versions[versions.Len()-1]
+}


### PR DESCRIPTION
Fixes #129 

This PR introduces a new child command (`lstn scan`) that scans all the dependencies in the `package.json` file in bulk.

The version constraints (eg., `"node-fetch": "^2.6.7"`) get resolved as per semantic versioning rules against the actual versions on the `npm` registry.

Notice this command **DOES NOT** generates any lock file to obtain the full dependencies tree, thus it does not use the `npm` executable.



- [ ] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [ ] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [ ] I have written unit tests
- [ ] I have made sure that the pull request is of reasonable size and can be easily reviewed
