### PR TITLE
feat!: make the scan child command the new default one

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -267,7 +267,7 @@ func New(ctx context.Context) (*Command, error) {
 	// Fallback to the default subcommand when the user doesn't specify one explicitly.
 	c, _, err := rootCmd.Find(os.Args[1:])
 	if err == nil && c.Use == rootCmd.Use && c.Flags().Parse(os.Args[1:]) != pflag.ErrHelp {
-		args := append([]string{inCmd.Name()}, os.Args[1:]...)
+		args := append([]string{scanCmd.Name()}, os.Args[1:]...)
 		rootCmd.SetArgs(args)
 	}
 


### PR DESCRIPTION
Fixes #141 

This PR makes the `lstn` CLI automatically fall back to `lstn scan` when it gets called without any child command.

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
