### PR TITLE
ci: switch to setup-go@v4 with automatic cache management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,13 @@ jobs:
 
     steps:
 
+      - name: Check out the source code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.GO_VERSION }}
           check-latest: true
@@ -46,21 +51,6 @@ jobs:
           go env
           printf "\n\nSystem environment:\n\n"
           env
-
-      - name: Cache the build cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: build-go-${{ matrix.go }}-${{ matrix.goos }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            build-go-${{ matrix.go }}-${{ matrix.goos }}
-
-      - name: Check out the source code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Build the make/make tool
         run: go build -o make/make make/main.go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,21 +23,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
 
       - name: Check out the source code
         uses: actions/checkout@v3
 
-      - name: Restore the Go modules cache
-        uses: actions/cache@v3
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4
         with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
-          restore-keys: |
-            go-${{ runner.os }}-
+          go-version: 1.19
 
       - name: Verify the dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-
       - name: Check out the source code
         uses: actions/checkout@v3
         with:
@@ -27,13 +22,10 @@ jobs:
       - name: Force fetch upstream tags
         run: git fetch --force --tags
 
-      - name: Restore the Go modules cache
-        uses: actions/cache@v3
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4
         with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
-          restore-keys: |
-            go-${{ runner.os }}-
+          go-version: 1.19
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,21 +18,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-
       - name: Check out the source code
         uses: actions/checkout@v3
 
-      - name: Restore the Go modules cache
-        uses: actions/cache@v3
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4
         with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
-          restore-keys: |
-            go-${{ runner.os }}-
+          go-version: 1.19
 
       - name: Download Go modules
         run: go mod download


### PR DESCRIPTION
Waiting for the setup-go action to release v4 with automatic caching.

Fixes #153 

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
