### PR TITLE
ci: use common reviewpad file

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -1,31 +1,5 @@
-api-version: reviewpad.com/v3.x
-
-# For more details see https://docs.reviewpad.com/guides/syntax#label.
-labels:
-  small:
-    description: Pull request is small
-    color: "#76dbbe"
-  medium:
-    description: Pull request is medium
-    color: "#2986cc"
-  large:
-    description: Pull request is large
-    color: "#c90076"
-  dependencies:
-    description: Something about our dependencies
-    color: "#ff8722"
-  build:
-    description: Marks issues or pull requests regarding changes to the build tool
-    color: "#FCEA0F"
-  breaking-change:
-    description: Marks a pull request as introducing breaking changes
-    color: "#b3c9c9"
-  no-releasenotes:
-    description: To not include a pull request in the changelog
-    color: "#333635"
-  needs-review:
-    description: Marks a pull request as waiting for review
-    color: "#aa2297"
+extends:
+  - https://github.com/listendev/.github/blob/main/reviewpad/common.yml
 
 rules:
   - name: docs-changes
@@ -54,74 +28,6 @@ groups:
 
 # For more details see https://docs.reviewpad.com/guides/syntax#workflow.
 workflows:
-  # This workflow praises contributors on their pull request contributions.
-  # This helps contributors feel appreciated.
-  - name: praise-contributors
-    description: Praise contributors
-    always-run: true
-    if:
-      # Praise contributors on their first pull request.
-      - rule: $pullRequestCountBy($author()) == 1
-        extra-actions:
-          - $commentOnce($sprintf("Thank you @%s for your first contribution!", [$author()]))
-      # Praise contributors on their 10th pull request.
-      - rule: $pullRequestCountBy($author()) == 10
-        extra-actions:
-          - $commentOnce($sprintf("Way to go @%s... This is your 10th pull request! 🎉", [$author()]))
-
-  # This workflow validates that pull requests follow the conventional commits specification.
-  # This helps us automatically generate changelogs.
-  # For more details, see https://www.conventionalcommits.org/en/v1.0.0/.
-  # The unerlying parser is https://github.com/leodido/go-conventionalcommits.
-  - name: check-conventional-commits
-    description: Validate that pull requests follow the conventional commits
-    always-run: true
-    if:
-      - rule: $isDraft() == false
-    then:
-      # Check commits messages against the conventional commits specification
-      - $commitLint()
-      # Check pull request title against the conventional commits specification.
-      - $titleLint()
-
-  # This workflow validates best practices for pull request management.
-  # This helps developers follow best practices.
-  - name: best-practices
-    description: Validate best practices for pull request management
-    always-run: true
-    if:
-      # Warn pull requests that do not have an associated GitHub issue.
-      - rule: $hasLinkedIssues() == false
-        extra-actions:
-          - $warn("Please link an issue to the pull request")
-      # Warn pull requests if their description is empty.
-      - rule: $description() == ""
-        extra-actions:
-          - $warn("Please provide a description for the pull request")
-      # Warn pull request do not have a clean linear history.
-      - rule: $hasLinearHistory() == false
-        extra-actions:
-          - $warn("Please rebase your pull request on the latest changes")
-
-  # This workflow labels pull requests depending on the total number of lines changed.
-  # This helps pick pull requests based on their size and to incentivize small pull requests.
-  - name: size-labeling
-    description: Label pull request based on the number of lines changed
-    always-run: true
-    if:
-      - rule: $size($group("ignore-patterns")) < 100
-        extra-actions:
-          - $removeLabels(["medium", "large"])
-          - $addLabel("small")
-      - rule: $size($group("ignore-patterns")) >= 100 && $size($group("ignore-patterns")) < 300
-        extra-actions:
-          - $removeLabels(["small", "large"])
-          - $addLabel("medium")
-      - rule: $size($group("ignore-patterns")) >= 300
-        extra-actions:
-          - $removeLabels(["small", "medium"])
-          - $addLabel("large")
-
   # This workflow labels pull requests based on the pull request change type.
   # This helps pick pull requests based on their change type.
   - name: pulls-labelling


### PR DESCRIPTION
This pull request uses the Reviewpad common.yml specification to avoid duplication of common workflows across multiple repositories.

This pull request should only be merged after https://github.com/listendev/.github/pull/1.

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
