### PR TITLE
feat: exit without erroring out when the `gh-pull-comment` reporter is not running on a GitHub pull request

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -149,30 +149,31 @@ The verdicts it returns are listed by the name of each package and its specified
 
 			cs := io.ColorScheme()
 			for _, r := range scanOpts.Reporter.Types {
-				c.Printf("reporting using the %s reporter\n", cs.Gray(r.String()))
+				rString := cs.Gray(fmt.Sprintf("%q", r.String()))
+				c.Printf("Reporting using the %s reporter...\n", rString)
 
 				switch r {
 				case cmd.GitHubPullCommentReport:
 					rep, runnable, err := reporterfactory.Make(ctx, r)
-					if err != nil {
+					if runnable && err != nil {
 						return err
 					}
 					// Move on when the current reporter cannot run in the current context
 					if !runnable {
-						c.PrintErr("TODO: explain me why")
+						c.PrintErrf("Exiting: %s.\n", err)
 
 						continue
 					}
 
 					err = rep.Run(combinedResponse)
 					if err != nil {
-						return fmt.Errorf("error while executing reporter (%s): %w", r.String(), err)
+						return fmt.Errorf("error while executing the %q reporter: %w", r.String(), err)
 					}
-					c.Printf("%s report successfully sent using the %s reporter\n", cs.SuccessIcon(), cs.Gray(r.String()))
+					c.Printf("The report has been successfully sent using the %s reporter... %s\n", rString, cs.SuccessIcon())
 				case cmd.GitHubPullCheckReport:
-					c.PrintErrf("The %q reporter is coming soon...\n", r.String())
+					c.PrintErrf("The %s reporter is coming soon...\n", rString)
 				case cmd.GitHubPullReviewReport:
-					c.PrintErrf("The %q reporter is coming soon...\n", r.String())
+					c.PrintErrf("The %s reporter is coming soon...\n", rString)
 				}
 			}
 

--- a/pkg/reporter/gh/comment/comment.go
+++ b/pkg/reporter/gh/comment/comment.go
@@ -115,7 +115,10 @@ func (r *rep) Run(res listen.Response) error {
 	return nil
 }
 
-// TODO: do not execute on GitHub push events.
+// CanRun tells whether this reporter is being executed on a GitHub pull request
+// (in which case it returns a true value) or not.
 func (r *rep) CanRun() bool {
-	return true
+	ghOpts := r.opts.Reporter.GitHub
+
+	return ghOpts.Owner != "" && ghOpts.Repo != "" && ghOpts.Pull.ID != 0
 }


### PR DESCRIPTION
Fixes #205 

![image](https://user-images.githubusercontent.com/120051/228991011-4d619604-e1b3-491f-ba48-7d527b1e310b.png)


- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
