### PR TITLE
fix: ensure NewPackageLockJSONFromReader() populates the bytes private field while creating a PackageLockJSON instance

### DIFF
--- a/pkg/listen/types_test.go
+++ b/pkg/listen/types_test.go
@@ -335,7 +335,14 @@ func TestNewAnalysisRequest(t *testing.T) {
 }
 
 func TestAnalysisRequestMarshal(t *testing.T) {
-	validPackageLockJSON, _ := npm.NewPackageLockJSONFromBytes([]byte(heredoc.Doc(`{
+	validPackageLockJSON1, _ := npm.NewPackageLockJSONFromBytes([]byte(`{"name": "github-gist","version": "1.0.0","lockfileVersion": 1,"requires": true,"dependencies": {"@babel/runtime-corejs3": {"version": "7.12.1","resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz","integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==","dev": true,"requires": {"core-js-pure": "^3.0.0","regenerator-runtime": "^0.13.4"}}}}`))
+
+	validAnalysisRequest1, err := NewAnalysisRequest(validPackageLockJSON1)
+	assert.Nil(t, err)
+
+	validPackageLockBody1 := []byte(`"eyJuYW1lIjogImdpdGh1Yi1naXN0IiwidmVyc2lvbiI6ICIxLjAuMCIsImxvY2tmaWxlVmVyc2lvbiI6IDEsInJlcXVpcmVzIjogdHJ1ZSwiZGVwZW5kZW5jaWVzIjogeyJAYmFiZWwvcnVudGltZS1jb3JlanMzIjogeyJ2ZXJzaW9uIjogIjcuMTIuMSIsInJlc29sdmVkIjogImh0dHBzOi8vcmVnaXN0cnkubnBtanMub3JnL0BiYWJlbC9ydW50aW1lLWNvcmVqczMvLS9ydW50aW1lLWNvcmVqczMtNy4xMi4xLnRneiIsImludGVncml0eSI6ICJzaGE1MTItdW1oUEljTXJsQloyYVRXbFdqVXNlVzlMalFLeGkxZHBGbFFTOER6c3hCLy81Syt1NkdMVEMvSmxpUEtIc2Q1a0pWUElVNlgvSHkwWXZXT1lQY014Qnc9PSIsImRldiI6IHRydWUsInJlcXVpcmVzIjogeyJjb3JlLWpzLXB1cmUiOiAiXjMuMC4wIiwicmVnZW5lcmF0b3ItcnVudGltZSI6ICJeMC4xMy40In19fX0="`)
+
+	validPackageLockJSON3, _ := npm.NewPackageLockJSONFromBytes([]byte(heredoc.Doc(`{
 		"name": "sample",
 		"version": "1.0.0",
 		"lockfileVersion": 3,
@@ -363,10 +370,10 @@ func TestAnalysisRequestMarshal(t *testing.T) {
 		}
 	}`)))
 
-	validAnalysisRequest, err := NewAnalysisRequest(validPackageLockJSON)
+	validAnalysisRequest3, err := NewAnalysisRequest(validPackageLockJSON3)
 	assert.Nil(t, err)
 
-	validPackageLockBody := []byte(`"ewoJIm5hbWUiOiAic2FtcGxlIiwKCSJ2ZXJzaW9uIjogIjEuMC4wIiwKCSJsb2NrZmlsZVZlcnNpb24iOiAzLAoJInJlcXVpcmVzIjogdHJ1ZSwKCSJwYWNrYWdlcyI6IHsKCQkiIjogewoJCQkibmFtZSI6ICJzYW1wbGUiLAoJCQkidmVyc2lvbiI6ICIxLjAuMCIsCgkJCSJsaWNlbnNlIjogIklTQyIsCgkJCSJkZXBlbmRlbmNpZXMiOiB7CgkJCQkicmVhY3QiOiAiMTguMC4wIgoJCQl9CgkJfSwKCQkibm9kZV9tb2R1bGVzL0BiYWJlbC9ydW50aW1lIjogewoJCQkidmVyc2lvbiI6ICI3LjIwLjEzIiwKCQkJInJlc29sdmVkIjogImh0dHBzOi8vcmVnaXN0cnkubnBtanMub3JnL0BiYWJlbC9ydW50aW1lLy0vcnVudGltZS03LjIwLjEzLnRneiIsCgkJCSJpbnRlZ3JpdHkiOiAic2hhNTEyLWd0M1BLWHMwREJvTDl4Q3ZPSUlaMk5FcUFHWnFIakFubVZiZlF0QjYyMFYwdVJlSVF1dHBlbDE0S2NuZVp1ZXI3VWlvWThBTEtaN2lvY2F2dnpUTkZBPT0iLAoJCQkiZGVwZW5kZW5jaWVzIjogewoJCQkJInJlZ2VuZXJhdG9yLXJ1bnRpbWUiOiAiXjAuMTMuMTEiCgkJCX0sCgkJCSJlbmdpbmVzIjogewoJCQkJIm5vZGUiOiAiPj02LjkuMCIKCQkJfQoJCX0KCX0KfQ=="`)
+	validPackageLockBody3 := []byte(`"ewoJIm5hbWUiOiAic2FtcGxlIiwKCSJ2ZXJzaW9uIjogIjEuMC4wIiwKCSJsb2NrZmlsZVZlcnNpb24iOiAzLAoJInJlcXVpcmVzIjogdHJ1ZSwKCSJwYWNrYWdlcyI6IHsKCQkiIjogewoJCQkibmFtZSI6ICJzYW1wbGUiLAoJCQkidmVyc2lvbiI6ICIxLjAuMCIsCgkJCSJsaWNlbnNlIjogIklTQyIsCgkJCSJkZXBlbmRlbmNpZXMiOiB7CgkJCQkicmVhY3QiOiAiMTguMC4wIgoJCQl9CgkJfSwKCQkibm9kZV9tb2R1bGVzL0BiYWJlbC9ydW50aW1lIjogewoJCQkidmVyc2lvbiI6ICI3LjIwLjEzIiwKCQkJInJlc29sdmVkIjogImh0dHBzOi8vcmVnaXN0cnkubnBtanMub3JnL0BiYWJlbC9ydW50aW1lLy0vcnVudGltZS03LjIwLjEzLnRneiIsCgkJCSJpbnRlZ3JpdHkiOiAic2hhNTEyLWd0M1BLWHMwREJvTDl4Q3ZPSUlaMk5FcUFHWnFIakFubVZiZlF0QjYyMFYwdVJlSVF1dHBlbDE0S2NuZVp1ZXI3VWlvWThBTEtaN2lvY2F2dnpUTkZBPT0iLAoJCQkiZGVwZW5kZW5jaWVzIjogewoJCQkJInJlZ2VuZXJhdG9yLXJ1bnRpbWUiOiAiXjAuMTMuMTEiCgkJCX0sCgkJCSJlbmdpbmVzIjogewoJCQkJIm5vZGUiOiAiPj02LjkuMCIKCQkJfQoJCX0KCX0KfQ=="`)
 
 	tests := []struct {
 		desc    string
@@ -376,9 +383,15 @@ func TestAnalysisRequestMarshal(t *testing.T) {
 		wantErr string
 	}{
 		{
-			desc:    "valid",
-			areq:    validAnalysisRequest,
-			lock:    validPackageLockBody,
+			desc:    "valid version 1",
+			areq:    validAnalysisRequest1,
+			lock:    validPackageLockBody1,
+			wantErr: "",
+		},
+		{
+			desc:    "valid version 3",
+			areq:    validAnalysisRequest3,
+			lock:    validPackageLockBody3,
 			wantErr: "",
 		},
 		{
@@ -397,8 +410,6 @@ func TestAnalysisRequestMarshal(t *testing.T) {
 					assert.Equal(t, tc.wantErr, err.Error())
 				}
 			} else {
-				assert.Nil(t, err)
-
 				var o map[string]json.RawMessage
 				e := json.Unmarshal(res, &o)
 				assert.Nil(t, e)

--- a/pkg/npm/testdata/package-lock.json
+++ b/pkg/npm/testdata/package-lock.json
@@ -1,0 +1,18 @@
+{
+    "name": "github-gist",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/runtime-corejs3": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz",
+            "integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==",
+            "dev": true,
+            "requires": {
+                "core-js-pure": "^3.0.0",
+                "regenerator-runtime": "^0.13.4"
+            }
+        }
+    }
+}

--- a/pkg/npm/types.go
+++ b/pkg/npm/types.go
@@ -16,6 +16,7 @@
 package npm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -181,10 +182,12 @@ func NewPackageLockJSONFromDir(ctx context.Context, dir string) (PackageLockJSON
 // NewPackageLockJSONFromReader creates a PackageLockJSON instance from by reading the contents of a package-lock.json file.
 func NewPackageLockJSONFromReader(reader io.Reader) (PackageLockJSON, error) {
 	ret := &packageLockJSON{}
-	if err := json.NewDecoder(reader).Decode(ret); err != nil {
+	var b bytes.Buffer
+	r := io.TeeReader(reader, &b)
+	if err := json.NewDecoder(r).Decode(ret); err != nil {
 		return nil, fmt.Errorf("couldn't instantiate from the input package-lock.json contents")
 	}
-	// TODO > set ret.bytes (TeeReader)
+	ret.bytes = b.Bytes()
 
 	return ret, nil
 }

--- a/pkg/npm/types_test.go
+++ b/pkg/npm/types_test.go
@@ -16,11 +16,15 @@
 package npm
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackageStruct(t *testing.T) {
@@ -344,4 +348,19 @@ func TestNewPackageJSONFromReader(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewPackageLockJSONFromReader(t *testing.T) {
+	fixture, errFixture := os.Open("testdata/package-lock.json")
+	assert.Nil(t, errFixture)
+	defer fixture.Close()
+
+	var b bytes.Buffer
+	r := io.TeeReader(fixture, &b)
+
+	lockFromDir, errFromDir := NewPackageLockJSONFromReader(r)
+	assert.Nil(t, errFromDir)
+	require.IsType(t, &packageLockJSON{}, lockFromDir)
+
+	assert.Equal(t, b.Bytes(), lockFromDir.(*packageLockJSON).bytes)
 }


### PR DESCRIPTION
Fixes #230 

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
