### PR TITLE
feat: make lstn in able to analyse multiple lockfiles from different ecosystems (NPM, PyPi) at once

### DIFF
--- a/pkg/cmd/arguments/dir_test.go
+++ b/pkg/cmd/arguments/dir_test.go
@@ -1,0 +1,88 @@
+package arguments
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/listendev/pkg/lockfile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLockfiles(t *testing.T) {
+	type testCase struct {
+		inputCWD       string
+		inputLockfiles []string
+		wantLockfiles  map[string]lockfile.Lockfile
+		wantErrors     map[lockfile.Lockfile][]error
+	}
+
+	cases := []testCase{
+		{
+			inputCWD:       "testdata",
+			inputLockfiles: []string{"package-lock.json"},
+			wantLockfiles: map[string]lockfile.Lockfile{
+				"testdata/package-lock.json": lockfile.PackageLockJSON,
+			},
+			wantErrors: map[lockfile.Lockfile][]error{},
+		},
+		{
+			inputCWD:       "testdata",
+			inputLockfiles: []string{"package-lock.json", "package-lock.json"},
+			wantLockfiles: map[string]lockfile.Lockfile{
+				"testdata/package-lock.json": lockfile.PackageLockJSON,
+			},
+			wantErrors: map[lockfile.Lockfile][]error{},
+		},
+		{
+			inputCWD:       "testdata",
+			inputLockfiles: []string{"package-lock.json", "poetry.lock"},
+			wantLockfiles: map[string]lockfile.Lockfile{
+				"testdata/package-lock.json": lockfile.PackageLockJSON,
+				"testdata/poetry.lock":       lockfile.PoetryLock,
+			},
+			wantErrors: map[lockfile.Lockfile][]error{},
+		},
+		{
+			inputCWD:       "testdata",
+			inputLockfiles: []string{"package-lock.json", "poetry.lock", "1/poetry.lock"},
+			wantLockfiles: map[string]lockfile.Lockfile{
+				"testdata/package-lock.json": lockfile.PackageLockJSON,
+				"testdata/poetry.lock":       lockfile.PoetryLock,
+				"testdata/1/poetry.lock":     lockfile.PoetryLock,
+			},
+			wantErrors: map[lockfile.Lockfile][]error{},
+		},
+		{
+			inputCWD:       "testdata",
+			inputLockfiles: []string{"package-lock.json", "poetry.lock", "1/poetry.lock", "unk/package-lock.json", "not-existing/poetry.lock"},
+			wantLockfiles: map[string]lockfile.Lockfile{
+				"testdata/package-lock.json": lockfile.PackageLockJSON,
+				"testdata/poetry.lock":       lockfile.PoetryLock,
+				"testdata/1/poetry.lock":     lockfile.PoetryLock,
+			},
+			wantErrors: map[lockfile.Lockfile][]error{
+				lockfile.PackageLockJSON: {fmt.Errorf("testdata/unk/package-lock.json not found")},
+				lockfile.PoetryLock:      {fmt.Errorf("testdata/not-existing/poetry.lock not found")},
+			},
+		},
+		{
+			inputCWD:       "testdata",
+			inputLockfiles: []string{"unsupported-lockfile.json", "poetry.lock", "1/poetry.lock", "unk/package-lock.json", "not-existing/poetry.lock"},
+			wantLockfiles: map[string]lockfile.Lockfile{
+				"testdata/poetry.lock":   lockfile.PoetryLock,
+				"testdata/1/poetry.lock": lockfile.PoetryLock,
+			},
+			wantErrors: map[lockfile.Lockfile][]error{
+				lockfile.PackageLockJSON: {fmt.Errorf("testdata/unk/package-lock.json not found")},
+				lockfile.PoetryLock:      {fmt.Errorf("testdata/not-existing/poetry.lock not found")},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		gotLockfiles, gotErrors := GetLockfiles(tc.inputCWD, tc.inputLockfiles)
+		require.Equal(t, tc.wantLockfiles, gotLockfiles)
+		require.Equal(t, tc.wantErrors, gotErrors)
+	}
+
+}


### PR DESCRIPTION
This PR:
- introduces the mono repo support from a single `lstn in` invocation
- implements the logic to let `lstn in` execute multiple analysis in a single run

Supported ecosystems:
- NPM
- PyPI

Supported lockfiles:
- package-lock.json (NPM)
- poetry.lock (PyPI)

- [ ] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [ ] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [ ] I have written unit tests
- [ ] I have made sure that the pull request is of reasonable size and can be easily reviewed
