### PR TITLE
Feat: look for .lstn.yaml config file also into lstn in <dir>

### DIFF
--- a/cmd/in/in.go
+++ b/cmd/in/in.go
@@ -68,7 +68,8 @@ The verdicts it returns are listed by the name of each package and its specified
 		Args:              arguments.SingleDirectory, // Executes before RunE
 		ValidArgsFunction: arguments.SingleDirectoryActiveHelp,
 		Annotations: map[string]string{
-			"source": project.GetSourceURL(filename),
+			"source":   project.GetSourceURL(filename),
+			"subgroup": groups.WithDirectory.String(),
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			ctx = c.Context()

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -77,9 +77,13 @@ func New(ctx context.Context) (*Command, error) {
 			"source": project.GetSourceURL(filename),
 		},
 		PersistentPreRunE: func(c *cobra.Command, _ []string) error {
-			// Do not check for the config file if the command is not available (eg., help) or not core (eg., version)
 			withConfigFile := false
 			c, _, err := c.Find(os.Args[1:])
+			// If the child command is one of those taking in a directory as first argument, look for the config file in there too
+			if subgroup, hasSubgroup := c.Annotations["subgroup"]; hasSubgroup && subgroup == groups.WithDirectory.String() && len(os.Args) > 1 {
+				viper.AddConfigPath(os.Args[2])
+			}
+			// Do not check for the config file if the command is not available (eg., help) or not core (eg., version)
 			if err == nil && (c.IsAvailableCommand() && c.GroupID == groups.Core.ID) {
 				// If a config file is found, read it in
 				if err := viper.ReadInConfig(); err == nil {

--- a/pkg/cmd/groups/sub.go
+++ b/pkg/cmd/groups/sub.go
@@ -1,0 +1,11 @@
+package groups
+
+type Sub string
+
+const (
+	WithDirectory Sub = "with_directory"
+)
+
+func (s Sub) String() string {
+	return string(s)
+}


### PR DESCRIPTION
Adds support for `.lstn.yaml` config files into `<dir>`.

This way, when executing `lstn in <myproj>` the config file will be searched into the following paths:
- $HOME/.lstn.yaml
- $

Notice: this behavior is only for `lstn in` child command, at the moment.

- [ ] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [ ] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [ ] I have written unit tests
- [ ] I have made sure that the pull request is of reasonable size and can be easily reviewed
