### PR TITLE
fix: do not concatenate to the lstn current working dir the lock files which path is an absolute one

### DIFF
--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -202,3 +202,12 @@ func EnvSetter(envs map[string]string) (closer func()) {
 		}
 	}
 }
+
+func StringsReplaceAll(slice []string, with string) []string {
+	ret := []string{}
+	for _, s := range slice {
+		ret = append(ret, strings.ReplaceAll(s, "_CWD_", with))
+	}
+
+	return ret
+}

--- a/pkg/cmd/arguments/dir.go
+++ b/pkg/cmd/arguments/dir.go
@@ -63,6 +63,10 @@ func GetDirectory(args []string) (string, error) {
 
 func GetLockfiles(cwd string, lockfiles []string) (map[string]lockfile.Lockfile, map[lockfile.Lockfile][]error) {
 	paths := goneric.MapSlice(func(f string) string {
+		if filepath.IsAbs(f) {
+			return f
+		}
+
 		return filepath.Join(cwd, f)
 	}, lockfiles)
 


### PR DESCRIPTION


<!--
  Thank you for contributing to the lstn CLI.
  To reference an open issue, please write this in your description: `Fixes #ISSUE_NUMBER`

  Also, please include:
  - a summary of the change and what type of change it is (new feature, bug fix, refactoring, docs)
  - motivation and context
-->

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
