### PR TITLE
feat(cmd/ci): make `lstn ci` run also on GitHub events different that `pull_request`

### DIFF
--- a/cmd/ci/ci.go
+++ b/cmd/ci/ci.go
@@ -101,11 +101,6 @@ This command requires a listen.dev pro account.`,
 			io := c.Context().Value(pkgcontext.IOStreamsKey).(*iostreams.IOStreams)
 			cs := io.ColorScheme()
 
-			if !info.IsGitHubPullRequest() {
-				c.PrintErrln(cs.WarningIcon(), "lstn ci only runs on GitHub pull requests at the moment")
-
-				return nil
-			}
 			// Block when running on fork pull requests
 			if info.HasReadOnlyGitHubToken() {
 				c.PrintErrln(cs.WarningIcon(), "lstn ci doesn not run on fork pull requests at the moment")


### PR DESCRIPTION
Since `lstn ci` job is to spawn argus's systemd service there's no reason to block it on GitHub events that are not referring to pull requests.

I kept it blocked on forked pull requests instead (at least until I have a clearer vision on this).

<!--
  Thank you for contributing to the lstn CLI.
  To reference an open issue, please write this in your description: `Fixes #ISSUE_NUMBER`

  Also, please include:
  - a summary of the change and what type of change it is (new feature, bug fix, refactoring, docs)
  - motivation and context
-->

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
