### PR TITLE
fix: Show help menu when missing arg in `lstn ci`

### DIFF
--- a/cmd/ci/ci.go
+++ b/cmd/ci/ci.go
@@ -49,6 +49,7 @@ A listen.dev pro is necessary.`,
 		},
 		Args: func(c *cobra.Command, args []string) error {
 			if err := cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)(c, args); err != nil {
+				_ = c.Help()
 				return err
 			}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to the lstn CLI.
  To reference an open issue, please write this in your description: `Fixes #ISSUE_NUMBER`

  Also, please include:
  - a summary of the change and what type of change it is (new feature, bug fix, refactoring, docs)
  - motivation and context
-->

- [x] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [x] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
