### PR TITLE
ci: remove hardcoded image for e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,8 +213,6 @@ jobs:
       lstn-use-release: false
       # The artifact to use we built previously.
       lstn-binary-artefact: artifact-linux
-      # Once https://github.com/listendev/jibril/pull/369 is merged we can use main.
-      jibril-image: ghcr.io/listendev/jibril:sha-196b297
     secrets:
       # We have to use a PAT to ensure we can checkout the other repo and access containers from other repos.
       github-token: ${{ secrets.CI_PAT }}


### PR DESCRIPTION
Removed the usage of a hardcoded image for e2e now the PR has merged: https://github.com/listendev/jibril/pull/369.

- [X] I have read the [contributing guidelines](https://github.com/listendev/lstn/blob/main/.github/CONTRIBUTING.md)
- [X] I have followed the [coding guidelines](https://github.com/listendev/lstn/blob/main/docs/coding-guidelines.md)
- [ ] I have written unit tests
- [X] I have made sure that the pull request is of reasonable size and can be easily reviewed
